### PR TITLE
Modify cursor when hover over mat-card-title

### DIFF
--- a/src/app/shared/issue-pr-card/issue-pr-card-header/issue-pr-card-header.component.css
+++ b/src/app/shared/issue-pr-card/issue-pr-card-header/issue-pr-card-header.component.css
@@ -12,6 +12,10 @@ span.octicon {
   word-break: break-word;
 }
 
+.mat-card-title:hover {
+  cursor: pointer;
+}
+
 .column-header .mat-card-title {
   font-size: 14px;
 }


### PR DESCRIPTION
### Type of change:

- UI Enhancement

### Changes Made:

- Add CSS property for cursor when `hover`

### Screenshots:

Current:
![image](https://github.com/JiaXinEu/WATcher/assets/108446221/e38f1d87-60fe-490e-990b-cc4b5d823b18)

In this pr:
![image](https://github.com/JiaXinEu/WATcher/assets/108446221/ab9d4063-4499-4617-b75d-497111a06b42)


### Proposed Commit Message:

```
Modify cursor property when hover over card title

Cursor indicates text selection when put over title. It should indicate
clickable link.

Let's make cursor a pointer when put over title.
```

